### PR TITLE
Rc 995

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,3 +209,8 @@ Added:
 
 - Updated native Roam SDK versions. Android v0.0.30 and iOS v0.0.31
 - Fixed `OFFLINE` input for Tracking config NetworkState
+
+## 0.0.40
+
+- Updated native Roam SDK iOS version iOS v0.0.36
+- Added `altitude`, `elevationGain`, and `totalElevationGain` in `trip_status` listener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,5 +212,5 @@ Added:
 
 ## 0.0.40
 
-- Updated native Roam SDK iOS version iOS v0.0.36
+- Updated native Roam SDK iOS version v0.0.36
 - Added `altitude`, `elevationGain`, and `totalElevationGain` in `trip_status` listener

--- a/RNRoam.podspec
+++ b/RNRoam.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.source_files   = './*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'roam-ios', '0.0.31'
+  s.dependency 'roam-ios', '0.0.36'
 end

--- a/ios/RNRoam.m
+++ b/ios/RNRoam.m
@@ -805,6 +805,9 @@ RCT_EXPORT_METHOD(resetBatchReceiverConfig : (RCTResponseSenderBlock)successCall
            [dict setValue:[NSNumber numberWithDouble:trip.duration] forKey:@"duration"];
            [dict setValue:[NSNumber numberWithDouble:trip.speed] forKey:@"speed"];
            [dict setValue:[NSNumber numberWithDouble:trip.pace] forKey:@"pace"];
+           [dict setValue:[NSNumber numberWithDouble:trip.altitude] forKey:@"altitude"];
+           [dict setValue:[NSNumber numberWithDouble:trip.elevationGain] forKey:@"elevationGain"];
+           [dict setValue:[NSNumber numberWithDouble:trip.totalElevationGain] forKey:@"totalElevationGain"];
            [dict setValue:trip.startedTime forKey:@"startedTime"];
            [dict setValue:trip.recordedAt forKey:@"recordedAt"];
            [array addObject:dict];

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "This plugin allows to use the Roam.ai SDK in your React Native mobile application on iOS and Android.",
   "homepage": "https://roam.ai",
   "license": "MIT",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "author": "Roam B.V",
   "main": "js/index.js",
   "dependencies": {


### PR DESCRIPTION
- Updated native Roam SDK iOS version v0.0.36
- Added `altitude`, `elevationGain`, and `totalElevationGain` in `trip_status` listener